### PR TITLE
Make go get command clearer for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ At the moment this is a Proof of Concept - feedback and ideas very welcome.
 
 ## Installation
 
-* Clone this repo (or go get aquasecurity/manifesto)
+* Clone this repo (or `go get github.com/aquasecurity/manifesto`)
 * Go to the directory and `go build .`
 
 ## Usage


### PR DESCRIPTION
The current text assumes go knowledge as well as go being installed, it feels clearer to include the explicit command to install manifesto into your Go environment.